### PR TITLE
Revert Vortice.DirectStorage version

### DIFF
--- a/FF16Tools.Pack/FF16Tools.Pack.csproj
+++ b/FF16Tools.Pack/FF16Tools.Pack.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Syroot.BinaryData" Version="5.2.2" />
     <PackageReference Include="Syroot.BinaryData.Memory" Version="5.2.2" />
     <PackageReference Include="System.IO.Hashing" Version="10.0.1" />
-    <PackageReference Include="Vortice.DirectStorage" Version="3.8.1" />
+    <PackageReference Include="Vortice.DirectStorage" Version="3.6.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Vortice.DirectStorage 3.8.1 seemed to cause unpacker to work unproperly. Reverting to 3.6.2 seems to fix this issue.